### PR TITLE
THY-313 - Task Type missing in time entries end point

### DIFF
--- a/KarbonAPI.json
+++ b/KarbonAPI.json
@@ -12266,6 +12266,11 @@
             "example": "Tax Return",
             "description": "The type of task performed by the user"
           },
+          "TaskTypeIsBillable": {
+            "type": "boolean",
+            "example": true,
+            "description": "Indicates whether the task type is configured as billable. A value of false means the time entry will not be billed regardless of the entity's billing type or the entry's BilledStatus."
+          },
           "Date": {
             "type": "string",
             "format": "date-time",


### PR DESCRIPTION
* Docs update for https://github.com/karbonhq/KarbonHQ-Application/pull/21829

THY-313

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change adding a new schema field; no runtime or behavioral changes.
> 
> **Overview**
> Updates the OpenAPI spec (`KarbonAPI.json`) for time entries to include a new boolean field, `TaskTypeIsBillable`, clarifying when a time entry will be billed regardless of entity billing type or `BilledStatus`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc294233dde68551aafde48c6814ba60f8094eb9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->