### PR TITLE
Correct bearer token location in auth section

### DIFF
--- a/KARBON_API.md
+++ b/KARBON_API.md
@@ -23,8 +23,10 @@ Authorization: Bearer {token}
 AccessKey: {key}
 ```
 
-- **`Authorization` token** — GUID format: `550e8400-e29b-41d4-a716-446655440000`. Obtained by registering at the Karbon Developer Center.
-- **`AccessKey`** — JWT format: three Base64URL parts separated by dots, starts with `eyJ...`. Found in Karbon under **Settings → Connected Apps → {Your API Application}**.
+Both values are issued together from the same API Application in Karbon. Find them under **Settings → Connected Apps → API Applications → {Your API Application}**.
+
+- **`Authorization` token** — GUID format: `550e8400-e29b-41d4-a716-446655440000`.
+- **`AccessKey`** — JWT format: three Base64URL parts separated by dots, starts with `eyJ...`.
 
 ---
 


### PR DESCRIPTION
The Authentication section previously said the `Authorization` token was "obtained by registering at the Karbon Developer Center". It's actually issued alongside the AccessKey from a customer's API Application in Karbon — Settings → Connected Apps → API Applications → {your application}.

This updates the section so both values share a single "where to find them" line pointing at that location.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to authentication guidance; no runtime or security code.
> 
> **Overview**
> The **Authentication** section in `KARBON_API.md` now states that the `Authorization` bearer token and `AccessKey` are issued together from the same Karbon API Application, with a single navigation path: **Settings → Connected Apps → API Applications → {Your API Application}**.
> 
> It removes the prior note that the bearer token is obtained by registering at the Karbon Developer Center. Token format descriptions (GUID vs JWT) are unchanged and listed under the shared location.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 339b4f05f8e78e278b0d50ec18b6c221ff10cd3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->